### PR TITLE
Flush out BFF and create Renovation Highlight Page

### DIFF
--- a/app/BFF/WebBFF.ts
+++ b/app/BFF/WebBFF.ts
@@ -1,6 +1,6 @@
 import type { ListingInterface } from "~/components/types/ListingInterface";
 import { AxiosInstance } from "./API/AxiosInstance";
-import { BuildRenovationListing, GetListingIdByURL } from "./WebBFFHelper";
+import { BuildRenovationListing, GetListingIdByURL, IsValidURL } from "./WebBFFHelper";
 import type { RenovationInputInterface } from "~/components/types/RenovationInputInterface";
 import type { FullListingDetailInterface } from "~/components/types/FullListingDetailInterface";
 import type { ListingResponseInterface } from "~/components/types/ListingResponseInterface";
@@ -29,6 +29,12 @@ export async function GetFullListingDetail(
   url: string,
 ): Promise<FullListingDetailInterface> {
   try {
+    //validating the url
+    if(!IsValidURL(url)) {
+      alert("Invalid URL.")
+      throw new Error("Invalid URL");
+    }
+
     let id: number | null = await GetListingIdByURL(url);
     let predictedData;
 
@@ -56,6 +62,7 @@ export async function GetFullListingDetail(
     };
   } catch (error) {
     console.error("GET Listing failed:", error);
+    alert("Could not find listing.")
     throw error;
   }
 }

--- a/app/BFF/WebBFF.ts
+++ b/app/BFF/WebBFF.ts
@@ -1,6 +1,10 @@
 import type { ListingInterface } from "~/components/types/ListingInterface";
 import { AxiosInstance } from "./API/AxiosInstance";
-import { BuildRenovationListing, GetListingIdByURL, IsValidURL } from "./WebBFFHelper";
+import {
+  BuildRenovationListing,
+  GetListingIdByURL,
+  IsValidURL,
+} from "./WebBFFHelper";
 import type { RenovationInputInterface } from "~/components/types/RenovationInputInterface";
 import type { FullListingDetailInterface } from "~/components/types/FullListingDetailInterface";
 import type { ListingResponseInterface } from "~/components/types/ListingResponseInterface";
@@ -27,13 +31,14 @@ export async function CreateListing(
   }
 }
 //Get the listing and renovation data base on the URL
+/*
 export async function GetFullListingDetail(
   url: string,
 ): Promise<FullListingDetailInterface> {
   try {
     //validating the url
-    if(!IsValidURL(url)) {
-      alert("Invalid URL.")
+    if (!IsValidURL(url)) {
+      alert("Invalid URL.");
       throw new Error("Invalid URL");
     }
 
@@ -51,9 +56,9 @@ export async function GetFullListingDetail(
       );
       CreateRenovation(renovationListing);
       const photoDetail = await ReadListingPhotos(id);
-      console.log("Photos:", photoDetail);
-      console.log("Is array:", Array.isArray(photoDetail));
-      await Promise.all(photoDetail.map( photo => ClassifyPhoto(photo.photo_id)));
+      await Promise.all(
+        photoDetail.map((photo) => ClassifyPhoto(photo.photo_id)),
+      );
     }
 
     //getting data
@@ -62,13 +67,90 @@ export async function GetFullListingDetail(
     const photoDetail = await ReadListingPhotos(id);
 
     return {
-      listing: listingData,
+      //listing: listingData,
       renovation: renovationData,
       photos: photoDetail,
     };
   } catch (error) {
     console.error("GET Listing failed:", error);
-    alert("Could not find listing.")
+    alert("Could not find listing.");
+    throw error;
+  }
+}
+*/
+//frontend function to get listing detail
+export async function GetListingByURL(
+  url: string,
+): Promise<ListingResponseInterface> {
+  try {
+    //validating the url
+    if (!IsValidURL(url)) {
+      alert("Invalid URL.");
+      throw new Error("Invalid URL");
+    }
+
+    let id: number | null = await GetListingIdByURL(url);
+
+    //if no listing is found, we will create a listing by url
+    if (id == null) {
+      const data = await CreateListing(url);
+      id = data.listing_id;
+      //predictedData = await PredictRenovation(data.description);
+      //let renovationListing = BuildRenovationListing(
+      //id,
+      //predictedData.result.items,
+      //);
+      //CreateRenovation(renovationListing);
+      //const photoDetail = await ReadListingPhotos(id);
+      //await Promise.all(
+      //photoDetail.map((photo) => ClassifyPhoto(photo.photo_id)),
+      //);
+    }
+
+    //getting data
+    const listingData = await GetListing(id);
+    //const renovationData = await ReadRenovation(id);
+    //const photoDetail = await ReadListingPhotos(id);
+
+    return listingData;
+  } catch (error) {
+    console.error("GET Listing failed:", error);
+    alert("Could not find listing.");
+    throw error;
+  }
+}
+
+//front end function to read photo and classify them
+export async function ReadAndClassifyPhoto(
+  id: number,
+): Promise<PhotoListing[]> {
+  let photoDetail = await ReadListingPhotos(id);
+  await Promise.all(photoDetail.map((photo) => ClassifyPhoto(photo.photo_id)));
+  photoDetail = await ReadListingPhotos(id);
+
+  return photoDetail;
+}
+
+//frontend function to predict renovation
+export async function PredictRenovationWithDescription(
+  description: string,
+  id: number,
+): Promise<RenovationListingInterface> {
+  let renovationData: RenovationListingInterface =
+    await ReadRenovation(id);
+  try {
+    const predictData = await PredictRenovation(description);
+    let renovationListing = BuildRenovationListing(
+      id,
+      predictData.result.items,
+    );
+    CreateRenovation(renovationListing);
+
+    renovationData = await ReadRenovation(id);
+
+    return renovationData;
+  } catch (error) {
+    console.error("PredictRenovationWithDescription function FAILED: ", error);
     throw error;
   }
 }
@@ -181,14 +263,13 @@ export async function ReadRenovation(
   }
 }
 //classify photo
-export async function ClassifyPhoto(photoId: number){
+export async function ClassifyPhoto(photoId: number) {
   try {
     await AxiosInstance.put("/photos/inference", null, {
-      params: { photo_id: photoId }, 
+      params: { photo_id: photoId },
     });
-  } catch(error) {
+  } catch (error) {
     console.error("Photo Classify request failed:", error);
     throw error;
   }
-
 }

--- a/app/BFF/WebBFF.ts
+++ b/app/BFF/WebBFF.ts
@@ -125,6 +125,10 @@ export async function ReadAndClassifyPhoto(
   id: number,
 ): Promise<PhotoListing[]> {
   let photoDetail = await ReadListingPhotos(id);
+  //return already classified photos
+  if(photoDetail.length > 0 && photoDetail[0].room_type) {
+    return photoDetail;
+  }
   await Promise.all(photoDetail.map((photo) => ClassifyPhoto(photo.photo_id)));
   photoDetail = await ReadListingPhotos(id);
 
@@ -135,10 +139,13 @@ export async function ReadAndClassifyPhoto(
 export async function PredictRenovationWithDescription(
   description: string,
   id: number,
-): Promise<RenovationListingInterface> {
-  let renovationData: RenovationListingInterface =
+): Promise<RenovationListingInterface[]> {
+  let renovationData: RenovationListingInterface[] =
     await ReadRenovation(id);
   try {
+    if(renovationData.length > 0) {
+      return renovationData;
+    }
     const predictData = await PredictRenovation(description);
     let renovationListing = BuildRenovationListing(
       id,
@@ -253,7 +260,7 @@ export async function GetListing(
 //Getting Renovation
 export async function ReadRenovation(
   listingId: number,
-): Promise<RenovationListingInterface> {
+): Promise<RenovationListingInterface[]> {
   try {
     const { data } = await AxiosInstance.get(`/renovations/${listingId}/read`);
     return data;

--- a/app/BFF/WebBFF.ts
+++ b/app/BFF/WebBFF.ts
@@ -64,7 +64,7 @@ export async function GetFullListingDetail(
     return {
       listing: listingData,
       renovation: renovationData,
-      photos: {photos: photoDetail},
+      photos: photoDetail,
     };
   } catch (error) {
     console.error("GET Listing failed:", error);

--- a/app/BFF/WebBFF.ts
+++ b/app/BFF/WebBFF.ts
@@ -7,6 +7,8 @@ import type { ListingResponseInterface } from "~/components/types/ListingRespons
 import type { PredictedRenovationResponse } from "~/components/types/PredictRenovationResponse";
 import type { RenovationListingInterface } from "~/components/types/RenovationListingInterface";
 import type { PhotoResponse } from "~/components/types/PhotoResponse";
+import type { PhotoClassification } from "~/components/types/PhotoClassification";
+import type { PhotoListing } from "~/components/types/PhotoListing";
 
 //Create a Listing
 export async function CreateListing(
@@ -48,6 +50,10 @@ export async function GetFullListingDetail(
         predictedData.result.items,
       );
       CreateRenovation(renovationListing);
+      const photoDetail = await ReadListingPhotos(id);
+      console.log("Photos:", photoDetail);
+      console.log("Is array:", Array.isArray(photoDetail));
+      await Promise.all(photoDetail.map( photo => ClassifyPhoto(photo.photo_id)));
     }
 
     //getting data
@@ -58,7 +64,7 @@ export async function GetFullListingDetail(
     return {
       listing: listingData,
       renovation: renovationData,
-      photos: photoDetail,
+      photos: {photos: photoDetail},
     };
   } catch (error) {
     console.error("GET Listing failed:", error);
@@ -141,7 +147,7 @@ export async function CreateRenovation(
 //Getting Photo details
 export async function ReadListingPhotos(
   listingId: number,
-): Promise<PhotoResponse> {
+): Promise<PhotoListing[]> {
   try {
     const { data } = await AxiosInstance.get(`/photos/${listingId}/read`);
     return data;
@@ -173,4 +179,16 @@ export async function ReadRenovation(
     console.error("GET Renovation request failed:", error);
     throw error;
   }
+}
+//classify photo
+export async function ClassifyPhoto(photoId: number){
+  try {
+    await AxiosInstance.put("/photos/inference", null, {
+      params: { photo_id: photoId }, 
+    });
+  } catch(error) {
+    console.error("Photo Classify request failed:", error);
+    throw error;
+  }
+
 }

--- a/app/BFF/WebBFF.ts
+++ b/app/BFF/WebBFF.ts
@@ -6,12 +6,9 @@ import {
   IsValidURL,
 } from "./WebBFFHelper";
 import type { RenovationInputInterface } from "~/components/types/RenovationInputInterface";
-import type { FullListingDetailInterface } from "~/components/types/FullListingDetailInterface";
 import type { ListingResponseInterface } from "~/components/types/ListingResponseInterface";
 import type { PredictedRenovationResponse } from "~/components/types/PredictRenovationResponse";
 import type { RenovationListingInterface } from "~/components/types/RenovationListingInterface";
-import type { PhotoResponse } from "~/components/types/PhotoResponse";
-import type { PhotoClassification } from "~/components/types/PhotoClassification";
 import type { PhotoListing } from "~/components/types/PhotoListing";
 
 //Create a Listing
@@ -30,54 +27,7 @@ export async function CreateListing(
     throw error;
   }
 }
-//Get the listing and renovation data base on the URL
-/*
-export async function GetFullListingDetail(
-  url: string,
-): Promise<FullListingDetailInterface> {
-  try {
-    //validating the url
-    if (!IsValidURL(url)) {
-      alert("Invalid URL.");
-      throw new Error("Invalid URL");
-    }
 
-    let id: number | null = await GetListingIdByURL(url);
-    let predictedData;
-
-    //if no listing is found, we will create a listing by url
-    if (id == null) {
-      const data = await CreateListing(url);
-      id = data.listing_id;
-      predictedData = await PredictRenovation(data.description);
-      let renovationListing = BuildRenovationListing(
-        id,
-        predictedData.result.items,
-      );
-      CreateRenovation(renovationListing);
-      const photoDetail = await ReadListingPhotos(id);
-      await Promise.all(
-        photoDetail.map((photo) => ClassifyPhoto(photo.photo_id)),
-      );
-    }
-
-    //getting data
-    const listingData = await GetListing(id);
-    const renovationData = await ReadRenovation(id);
-    const photoDetail = await ReadListingPhotos(id);
-
-    return {
-      //listing: listingData,
-      renovation: renovationData,
-      photos: photoDetail,
-    };
-  } catch (error) {
-    console.error("GET Listing failed:", error);
-    alert("Could not find listing.");
-    throw error;
-  }
-}
-*/
 //frontend function to get listing detail
 export async function GetListingByURL(
   url: string,
@@ -95,22 +45,10 @@ export async function GetListingByURL(
     if (id == null) {
       const data = await CreateListing(url);
       id = data.listing_id;
-      //predictedData = await PredictRenovation(data.description);
-      //let renovationListing = BuildRenovationListing(
-      //id,
-      //predictedData.result.items,
-      //);
-      //CreateRenovation(renovationListing);
-      //const photoDetail = await ReadListingPhotos(id);
-      //await Promise.all(
-      //photoDetail.map((photo) => ClassifyPhoto(photo.photo_id)),
-      //);
     }
 
     //getting data
     const listingData = await GetListing(id);
-    //const renovationData = await ReadRenovation(id);
-    //const photoDetail = await ReadListingPhotos(id);
 
     return listingData;
   } catch (error) {

--- a/app/BFF/WebBFF.ts
+++ b/app/BFF/WebBFF.ts
@@ -64,7 +64,7 @@ export async function ReadAndClassifyPhoto(
 ): Promise<PhotoListing[]> {
   let photoDetail = await ReadListingPhotos(id);
   //return already classified photos
-  if(photoDetail.length > 0 && photoDetail[0].room_type) {
+  if (photoDetail.length > 0 && photoDetail[0].room_type) {
     return photoDetail;
   }
   await Promise.all(photoDetail.map((photo) => ClassifyPhoto(photo.photo_id)));
@@ -78,10 +78,9 @@ export async function PredictRenovationWithDescription(
   description: string,
   id: number,
 ): Promise<RenovationListingInterface[]> {
-  let renovationData: RenovationListingInterface[] =
-    await ReadRenovation(id);
+  let renovationData: RenovationListingInterface[] = await ReadRenovation(id);
   try {
-    if(renovationData.length > 0) {
+    if (renovationData.length > 0) {
       return renovationData;
     }
     const predictData = await PredictRenovation(description);

--- a/app/BFF/WebBFFHelper.ts
+++ b/app/BFF/WebBFFHelper.ts
@@ -43,6 +43,6 @@ export function BuildRenovationListing(
 }
 //add a validation function
 export function IsValidURL(url: string) {
-    const pattern = /^https:\/\/www\.homes\.com\/property\/.+\/$/;
-    return pattern.test(url);
+  const pattern = /^https:\/\/www\.homes\.com\/property\/.+\/$/;
+  return pattern.test(url);
 }

--- a/app/BFF/WebBFFHelper.ts
+++ b/app/BFF/WebBFFHelper.ts
@@ -23,6 +23,7 @@ export async function GetListingIdByURL(url: string): Promise<number | null> {
   return match.listing_id;
 }
 
+//building payload for renovation endpoint
 export function BuildRenovationListing(
   listing_id: number,
   items: { name: string; renovated: boolean }[],
@@ -39,4 +40,9 @@ export function BuildRenovationListing(
     bedroom: getRenovated("bedroom"),
     basement: getRenovated("basement"),
   };
+}
+//add a validation function
+export function IsValidURL(url: string) {
+    const pattern = /^https:\/\/www\.homes\.com\/property\/.+\/$/;
+    return pattern.test(url);
 }

--- a/app/UtilityFunctions/HelperFunction.ts
+++ b/app/UtilityFunctions/HelperFunction.ts
@@ -1,40 +1,51 @@
 import type { PhotoListing } from "~/components/types/PhotoListing";
 import type { RenovationListingInterface } from "~/components/types/RenovationListingInterface";
 
-export const normalizeRoomName = (room: string) => room.toLowerCase().replace(/\s+/g, "_");
-export const getRenovatedRoom = (listing: RenovationListingInterface): string[] => {
-    return Object.entries(listing)
+export const normalizeRoomName = (room: string) =>
+  room.toLowerCase().replace(/\s+/g, "_");
+export const getRenovatedRoom = (
+  listing: RenovationListingInterface,
+): string[] => {
+  return Object.entries(listing)
     .filter(([key, value]) => key != "listing_id" && value === true)
-    .map(([key]) => key)
-}
+    .map(([key]) => key);
+};
 
-export const filterPhotoByRenovation = (photos: PhotoListing[], renovatedRooms: string[]) => {
-    if(!renovatedRooms || renovatedRooms.length === 0) {
-        return [];
+export const filterPhotoByRenovation = (
+  photos: PhotoListing[],
+  renovatedRooms: string[],
+) => {
+  if (!renovatedRooms || renovatedRooms.length === 0) {
+    return [];
+  }
+
+  const normalizedRooms = renovatedRooms.map(normalizeRoomName);
+
+  return photos.filter((photo) => {
+    if (!photo.room_type || typeof photo.room_type !== "string") {
+      return false;
     }
+    return normalizedRooms.includes(normalizeRoomName(photo.room_type));
+  });
+};
 
-    const normalizedRooms = renovatedRooms.map(normalizeRoomName);
-
-    return photos.filter((photo) => {
-        if(!photo.room_type || typeof photo.room_type !== "string") {
-            return false;
-        }
-        return normalizedRooms.includes(normalizeRoomName(photo.room_type))});
-}
-
-export const groupPhotosByRoom = (photos: PhotoListing[]): Record<string, PhotoListing[]> => {
-    const initialValue: Record<string, PhotoListing[]> = {};
-    return photos.reduce((acc: Record<string, PhotoListing[]>, photo: PhotoListing) => {
-        if(!photo.room_type) {
-            return acc;
-        }
-        if(!acc[photo.room_type]) {
-            acc[photo.room_type] = [];
-        }
-
-        acc[photo.room_type].push(photo);
-
+export const groupPhotosByRoom = (
+  photos: PhotoListing[],
+): Record<string, PhotoListing[]> => {
+  const initialValue: Record<string, PhotoListing[]> = {};
+  return photos.reduce(
+    (acc: Record<string, PhotoListing[]>, photo: PhotoListing) => {
+      if (!photo.room_type) {
         return acc;
-        
-    }, initialValue);
-}
+      }
+      if (!acc[photo.room_type]) {
+        acc[photo.room_type] = [];
+      }
+
+      acc[photo.room_type].push(photo);
+
+      return acc;
+    },
+    initialValue,
+  );
+};

--- a/app/UtilityFunctions/HelperFunction.ts
+++ b/app/UtilityFunctions/HelperFunction.ts
@@ -1,0 +1,40 @@
+import type { PhotoListing } from "~/components/types/PhotoListing";
+import type { RenovationListingInterface } from "~/components/types/RenovationListingInterface";
+
+export const normalizeRoomName = (room: string) => room.toLowerCase().replace(/\s+/g, "_");
+export const getRenovatedRoom = (listing: RenovationListingInterface): string[] => {
+    return Object.entries(listing)
+    .filter(([key, value]) => key != "listing_id" && value === true)
+    .map(([key]) => key)
+}
+
+export const filterPhotoByRenovation = (photos: PhotoListing[], renovatedRooms: string[]) => {
+    if(!renovatedRooms || renovatedRooms.length === 0) {
+        return [];
+    }
+
+    const normalizedRooms = renovatedRooms.map(normalizeRoomName);
+
+    return photos.filter((photo) => {
+        if(!photo.room_type || typeof photo.room_type !== "string") {
+            return false;
+        }
+        return normalizedRooms.includes(normalizeRoomName(photo.room_type))});
+}
+
+export const groupPhotosByRoom = (photos: PhotoListing[]): Record<string, PhotoListing[]> => {
+    const initialValue: Record<string, PhotoListing[]> = {};
+    return photos.reduce((acc: Record<string, PhotoListing[]>, photo: PhotoListing) => {
+        if(!photo.room_type) {
+            return acc;
+        }
+        if(!acc[photo.room_type]) {
+            acc[photo.room_type] = [];
+        }
+
+        acc[photo.room_type].push(photo);
+
+        return acc;
+        
+    }, initialValue);
+}

--- a/app/components/NavMenu.tsx
+++ b/app/components/NavMenu.tsx
@@ -4,7 +4,7 @@ import { NavButtonData } from "./NavButtonData";
 export const NavMenu = () => {
   return (
     <header className="border-b font-serif font-size-20 border-gray-200 bg-white ">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <div className="mx-auto flex items-center justify-between px-6 py-4">
         <ul className="flex space-x-8 font-medium">
           {NavButtonData.map((navItem) => (
             <NavBar key={navItem.label} navList={navItem} />

--- a/app/components/layouts/BeforeAfter.tsx
+++ b/app/components/layouts/BeforeAfter.tsx
@@ -2,16 +2,23 @@ import { NavMenu } from "../NavMenu";
 import { mockProperties, getPhotosByPropertyId } from "../DummyData";
 import { Link, useSearchParams } from "react-router";
 import { useEffect, useRef, useState } from "react";
-import { GetListingByURL, PredictRenovationWithDescription, ReadAndClassifyPhoto } from "~/BFF/WebBFF";
+import {
+  GetListingByURL,
+  PredictRenovationWithDescription,
+  ReadAndClassifyPhoto,
+} from "~/BFF/WebBFF";
 import { AddressField } from "../prototype/AddressField";
 import type { RenovationListingInterface } from "../types/RenovationListingInterface";
 import type { ListingResponseInterface } from "../types/ListingResponseInterface";
 import type { PhotoListing } from "../types/PhotoListing";
-import { filterPhotoByRenovation, getRenovatedRoom, groupPhotosByRoom } from "~/UtilityFunctions/HelperFunction";
+import {
+  filterPhotoByRenovation,
+  getRenovatedRoom,
+  groupPhotosByRoom,
+} from "~/UtilityFunctions/HelperFunction";
 import { Gallery } from "../prototype/Gallery";
 import { BannerGallery } from "../prototype/BannerGallery";
 import { Spinner } from "../prototype/Spinner";
-
 
 export const BeforeAfter = () => {
   const previousUrl = useRef<string | null>(null);
@@ -29,13 +36,15 @@ export const BeforeAfter = () => {
   const [searchParams] = useSearchParams();
   const url = searchParams.get("url");
   //some hooks use to store data
-  const[listing, setListing] = useState<ListingResponseInterface>();
-  const[renovation, setRenovation] = useState<RenovationListingInterface[]>();
-  const [groupedPhotos, setGroupedPhotos] = useState<Record<string, PhotoListing[]>>({});
+  const [listing, setListing] = useState<ListingResponseInterface>();
+  const [renovation, setRenovation] = useState<RenovationListingInterface[]>();
+  const [groupedPhotos, setGroupedPhotos] = useState<
+    Record<string, PhotoListing[]>
+  >({});
   const [loading, setLoading] = useState(false);
   const [galleryLoading, setGalleryLoading] = useState(false);
   const [photos, setPhotos] = useState<PhotoListing[]>();
-  
+
   //loading logic
   useEffect(() => {
     if (!url) return;
@@ -51,7 +60,10 @@ export const BeforeAfter = () => {
       setLoading(false);
 
       //getting and setting renovation detail
-      const renovationData = await PredictRenovationWithDescription(response.description, response.listing_id)
+      const renovationData = await PredictRenovationWithDescription(
+        response.description,
+        response.listing_id,
+      );
       setRenovation(renovationData);
 
       //get and classify photo
@@ -60,35 +72,33 @@ export const BeforeAfter = () => {
 
       //loading photo gallery
       await new Promise((res) => setTimeout(res, 50));
-      const renovatedRooms = getRenovatedRoom(renovationData[0])
-      const filteredPhotos = filterPhotoByRenovation(photoData, renovatedRooms)
+      const renovatedRooms = getRenovatedRoom(renovationData[0]);
+      const filteredPhotos = filterPhotoByRenovation(photoData, renovatedRooms);
       const grouped = groupPhotosByRoom(filteredPhotos);
       setGroupedPhotos(grouped);
       setGalleryLoading(false);
-
 
       //testing
       console.log(response);
       console.log(renovationData);
       console.log(grouped);
-
     };
 
     fetchData();
   }, [url]);
 
-
-
   return (
     <div className="text-black">
       <NavMenu />
-      <BannerGallery photos={photos || []} loading={galleryLoading}/>
-      <h1 className="text-3xl font-bold mt-7 text-center">Property Information</h1>
+      <BannerGallery photos={photos || []} loading={galleryLoading} />
+      <h1 className="text-3xl font-bold mt-7 text-center">
+        Property Information
+      </h1>
 
       <div className=" mx-auto p-6">
         <div className="rounded-lg p-6">
-          <AddressField listing={listing} loading={loading}/>
-          <Gallery groupedPhotos={groupedPhotos} loading={galleryLoading}/>
+          <AddressField listing={listing} loading={loading} />
+          <Gallery groupedPhotos={groupedPhotos} loading={galleryLoading} />
         </div>
       </div>
     </div>

--- a/app/components/layouts/BeforeAfter.tsx
+++ b/app/components/layouts/BeforeAfter.tsx
@@ -6,9 +6,11 @@ import { LivingRoom } from "../LivingRoom";
 import { Bedroom } from "../Bedroom";
 import { Basement } from "../Basement";
 import { House } from "../House";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
+import { useEffect, useState } from "react";
+import { GetFullListingDetail } from "~/BFF/WebBFF";
 
-export const BeforeAfterView = () => {
+export const BeforeAfter = () => {
   const sampleProperty = mockProperties[0];
   const propertyPhotos = getPhotosByPropertyId(sampleProperty.id);
   const uniqueRoomTypes = Array.from(
@@ -18,6 +20,26 @@ export const BeforeAfterView = () => {
     if (b == "house") return 1;
     return 0;
   });
+
+  //getting url from dashboard
+  const [searchParams] = useSearchParams();
+  const url = searchParams.get("url");
+  //some hooks use to store data
+  const[data, setData] = useState<any>(null);
+  const[loading, setLoading] = useState(false);
+  //loading logic
+  useEffect(() => {
+    if(!url) return;
+    const fetchData = async () => {
+      setLoading(true);
+      const response = await GetFullListingDetail(url);
+      console.log(response);
+      setLoading(false);
+    }
+
+    fetchData();
+  }, [url]);
+
   const housePhoto = propertyPhotos.find(
     (p) => p.room_type && p.room_type.toLowerCase() == "house",
   );
@@ -93,6 +115,13 @@ export const BeforeAfterView = () => {
     }
     return null;
   };
+
+  //loading
+  if(loading) {
+    return (
+      <p className="w-screen h-screen flex items-center justify-center">Loading...</p>
+    )
+  }
 
   return (
     <div className="text-black">

--- a/app/components/layouts/BeforeAfter.tsx
+++ b/app/components/layouts/BeforeAfter.tsx
@@ -1,11 +1,5 @@
 import { NavMenu } from "../NavMenu";
 import { mockProperties, getPhotosByPropertyId } from "../DummyData";
-import { Kitchen } from "../Kitchen";
-import { Bathroom } from "../Bathroom";
-import { LivingRoom } from "../LivingRoom";
-import { Bedroom } from "../Bedroom";
-import { Basement } from "../Basement";
-import { House } from "../House";
 import { Link, useSearchParams } from "react-router";
 import { useEffect, useRef, useState } from "react";
 import { GetListingByURL, PredictRenovationWithDescription, ReadAndClassifyPhoto } from "~/BFF/WebBFF";
@@ -13,6 +7,10 @@ import { AddressField } from "../prototype/AddressField";
 import type { RenovationListingInterface } from "../types/RenovationListingInterface";
 import type { ListingResponseInterface } from "../types/ListingResponseInterface";
 import type { PhotoListing } from "../types/PhotoListing";
+import { filterPhotoByRenovation, getRenovatedRoom, groupPhotosByRoom } from "~/UtilityFunctions/HelperFunction";
+import { Gallery } from "../prototype/Gallery";
+import { BannerGallery } from "../prototype/BannerGallery";
+import { Spinner } from "../prototype/Spinner";
 
 
 export const BeforeAfter = () => {
@@ -32,9 +30,12 @@ export const BeforeAfter = () => {
   const url = searchParams.get("url");
   //some hooks use to store data
   const[listing, setListing] = useState<ListingResponseInterface>();
-  const[renovation, setRenovation] = useState<RenovationListingInterface>();
-  const[photos, setPhotos] = useState<PhotoListing[]>();
+  const[renovation, setRenovation] = useState<RenovationListingInterface[]>();
+  const [groupedPhotos, setGroupedPhotos] = useState<Record<string, PhotoListing[]>>({});
   const [loading, setLoading] = useState(false);
+  const [galleryLoading, setGalleryLoading] = useState(false);
+  const [photos, setPhotos] = useState<PhotoListing[]>();
+  
   //loading logic
   useEffect(() => {
     if (!url) return;
@@ -44,6 +45,7 @@ export const BeforeAfter = () => {
     const fetchData = async () => {
       //getting and setting listing detail
       setLoading(true);
+      setGalleryLoading(true);
       const response = await GetListingByURL(url);
       setListing(response);
       setLoading(false);
@@ -56,110 +58,37 @@ export const BeforeAfter = () => {
       const photoData = await ReadAndClassifyPhoto(response.listing_id);
       setPhotos(photoData);
 
+      //loading photo gallery
+      await new Promise((res) => setTimeout(res, 50));
+      const renovatedRooms = getRenovatedRoom(renovationData[0])
+      const filteredPhotos = filterPhotoByRenovation(photoData, renovatedRooms)
+      const grouped = groupPhotosByRoom(filteredPhotos);
+      setGroupedPhotos(grouped);
+      setGalleryLoading(false);
+
 
       //testing
       console.log(response);
       console.log(renovationData);
-      console.log(photoData);
+      console.log(grouped);
+
     };
 
     fetchData();
   }, [url]);
 
-  const housePhoto = propertyPhotos.find(
-    (p) => p.room_type && p.room_type.toLowerCase() == "house",
-  );
-
-  const renderRoom = (photo: any) => {
-    const type = photo.room_type || "";
-    const linkTo = `/before-after/${photo.room_type}`;
-    if (type.toLowerCase() == "house") {
-      return (
-        <Link to={linkTo}>
-          <House
-            photo={photo}
-            address={sampleProperty.address}
-            onClick={() => {}}
-          />
-        </Link>
-      );
-    }
-    if (type.toLowerCase() == "kitchen") {
-      return (
-        <Link to={linkTo}>
-          <Kitchen
-            photo={photo}
-            address={sampleProperty.address}
-            onClick={() => {}}
-          />
-        </Link>
-      );
-    }
-    if (type.toLowerCase() == "bathroom") {
-      return (
-        <Link to={linkTo}>
-          <Bathroom
-            photo={photo}
-            address={sampleProperty.address}
-            onClick={() => {}}
-          />
-        </Link>
-      );
-    }
-    if (type.toLowerCase() == "living_room") {
-      return (
-        <Link to={linkTo}>
-          <LivingRoom
-            photo={photo}
-            address={sampleProperty.address}
-            onClick={() => {}}
-          />
-        </Link>
-      );
-    }
-    if (type.toLowerCase() == "bedroom") {
-      return (
-        <Link to={linkTo}>
-          <Bedroom
-            photo={photo}
-            address={sampleProperty.address}
-            onClick={() => {}}
-          />
-        </Link>
-      );
-    }
-    if (type.toLowerCase() == "basement") {
-      return (
-        <Link to={linkTo}>
-          <Basement
-            photo={photo}
-            address={sampleProperty.address}
-            onClick={() => {}}
-          />
-        </Link>
-      );
-    }
-    return null;
-  };
 
 
   return (
     <div className="text-black">
       <NavMenu />
-      <h1 className="text-3xl font-bold mt-7 text-center mb-6">Renovations</h1>
+      <BannerGallery photos={photos || []} loading={galleryLoading}/>
+      <h1 className="text-3xl font-bold mt-7 text-center">Property Information</h1>
 
-      <div className="max-w-6xl mx-auto p-6">
-        <div className="bg-gray-200 rounded-lg shadow-md p-6">
+      <div className=" mx-auto p-6">
+        <div className="rounded-lg p-6">
           <AddressField listing={listing} loading={loading}/>
-          <div className="space-y-6">
-            {uniqueRoomTypes.map((roomType) => {
-              const photo = propertyPhotos.find((p) => p.room_type == roomType);
-              if (photo) {
-                return <div key={roomType}>{renderRoom(photo)}</div>;
-              }
-              return null;
-            })}
-          </div>
+          <Gallery groupedPhotos={groupedPhotos} loading={galleryLoading}/>
         </div>
       </div>
     </div>

--- a/app/components/layouts/BeforeAfter.tsx
+++ b/app/components/layouts/BeforeAfter.tsx
@@ -8,7 +8,12 @@ import { Basement } from "../Basement";
 import { House } from "../House";
 import { Link, useSearchParams } from "react-router";
 import { useEffect, useRef, useState } from "react";
-import { GetFullListingDetail } from "~/BFF/WebBFF";
+import { GetListingByURL, PredictRenovationWithDescription, ReadAndClassifyPhoto } from "~/BFF/WebBFF";
+import { AddressField } from "../prototype/AddressField";
+import type { RenovationListingInterface } from "../types/RenovationListingInterface";
+import type { ListingResponseInterface } from "../types/ListingResponseInterface";
+import type { PhotoListing } from "../types/PhotoListing";
+
 
 export const BeforeAfter = () => {
   const previousUrl = useRef<string | null>(null);
@@ -26,7 +31,9 @@ export const BeforeAfter = () => {
   const [searchParams] = useSearchParams();
   const url = searchParams.get("url");
   //some hooks use to store data
-  const [data, setData] = useState<any>(null);
+  const[listing, setListing] = useState<ListingResponseInterface>();
+  const[renovation, setRenovation] = useState<RenovationListingInterface>();
+  const[photos, setPhotos] = useState<PhotoListing[]>();
   const [loading, setLoading] = useState(false);
   //loading logic
   useEffect(() => {
@@ -35,11 +42,25 @@ export const BeforeAfter = () => {
 
     previousUrl.current = url;
     const fetchData = async () => {
+      //getting and setting listing detail
       setLoading(true);
-      const response = await GetFullListingDetail(url);
-      setData(response);
-      console.log(response);
+      const response = await GetListingByURL(url);
+      setListing(response);
       setLoading(false);
+
+      //getting and setting renovation detail
+      const renovationData = await PredictRenovationWithDescription(response.description, response.listing_id)
+      setRenovation(renovationData);
+
+      //get and classify photo
+      const photoData = await ReadAndClassifyPhoto(response.listing_id);
+      setPhotos(photoData);
+
+
+      //testing
+      console.log(response);
+      console.log(renovationData);
+      console.log(photoData);
     };
 
     fetchData();
@@ -121,14 +142,6 @@ export const BeforeAfter = () => {
     return null;
   };
 
-  //loading
-  if (loading) {
-    return (
-      <p className="w-screen h-screen flex items-center justify-center">
-        Loading...
-      </p>
-    );
-  }
 
   return (
     <div className="text-black">
@@ -137,12 +150,7 @@ export const BeforeAfter = () => {
 
       <div className="max-w-6xl mx-auto p-6">
         <div className="bg-gray-200 rounded-lg shadow-md p-6">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            {sampleProperty.address}
-          </h2>
-
-          <p className="text-gray-700 mb-6">{sampleProperty.description}</p>
-
+          <AddressField listing={listing} loading={loading}/>
           <div className="space-y-6">
             {uniqueRoomTypes.map((roomType) => {
               const photo = propertyPhotos.find((p) => p.room_type == roomType);

--- a/app/components/layouts/BeforeAfter.tsx
+++ b/app/components/layouts/BeforeAfter.tsx
@@ -7,10 +7,11 @@ import { Bedroom } from "../Bedroom";
 import { Basement } from "../Basement";
 import { House } from "../House";
 import { Link, useSearchParams } from "react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { GetFullListingDetail } from "~/BFF/WebBFF";
 
 export const BeforeAfter = () => {
+  const previousUrl = useRef<string | null>(null);
   const sampleProperty = mockProperties[0];
   const propertyPhotos = getPhotosByPropertyId(sampleProperty.id);
   const uniqueRoomTypes = Array.from(
@@ -25,17 +26,21 @@ export const BeforeAfter = () => {
   const [searchParams] = useSearchParams();
   const url = searchParams.get("url");
   //some hooks use to store data
-  const[data, setData] = useState<any>(null);
-  const[loading, setLoading] = useState(false);
+  const [data, setData] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
   //loading logic
   useEffect(() => {
-    if(!url) return;
+    if (!url) return;
+    if (previousUrl.current === url) return;
+
+    previousUrl.current = url;
     const fetchData = async () => {
       setLoading(true);
       const response = await GetFullListingDetail(url);
+      setData(response);
       console.log(response);
       setLoading(false);
-    }
+    };
 
     fetchData();
   }, [url]);
@@ -117,10 +122,12 @@ export const BeforeAfter = () => {
   };
 
   //loading
-  if(loading) {
+  if (loading) {
     return (
-      <p className="w-screen h-screen flex items-center justify-center">Loading...</p>
-    )
+      <p className="w-screen h-screen flex items-center justify-center">
+        Loading...
+      </p>
+    );
   }
 
   return (

--- a/app/components/layouts/Dashboard.tsx
+++ b/app/components/layouts/Dashboard.tsx
@@ -9,30 +9,10 @@ import { LoadingScreen } from "./LoadingScreen";
 export const Dashboard = () => {
   //This is purely for testing purpose of BFF
   //Start of testing for BFF function
-  const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const runTest = async () => {
-      try {
-        setLoading(true);
-        const result = await GetFullListingDetail(
-          "https://www.homes.com/property/1517-oakwood-ave-richmond-va/h7d5kcbqnxje9/",
-        );
-        console.log("GET success:", result);
-      } catch (err) {
-        console.error("GET failed:", err);
-      } finally {
-        setLoading(false);
-      }
-    };
 
-    runTest();
-  }, []);
   //End of testing for BFF Function
 
-  if (loading) {
-    return <LoadingScreen />;
-  }
 
   return (
     <div className="flex-col h-full">

--- a/app/components/layouts/Dashboard.tsx
+++ b/app/components/layouts/Dashboard.tsx
@@ -6,13 +6,6 @@ import { useEffect, useState } from "react";
 import { LoadingScreen } from "./LoadingScreen";
 
 export const Dashboard = () => {
-  //This is purely for testing purpose of BFF
-  //Start of testing for BFF function
-
-
-  //End of testing for BFF Function
-
-
   return (
     <div className="flex-col h-full">
       <div className="flex-col h-140 bg-[url('/background.png')] bg-bottom bg-no-repeat bg-cover">

--- a/app/components/layouts/Dashboard.tsx
+++ b/app/components/layouts/Dashboard.tsx
@@ -1,4 +1,3 @@
-import { CreateListing, GetFullListingDetail } from "~/BFF/WebBFF";
 import { ExploreMore } from "../main-page/ExploreMore";
 import { ProjectSummary } from "../main-page/ProjectSummary";
 import { SearchBar } from "../main-page/SearchBar";

--- a/app/components/main-page/SearchField.tsx
+++ b/app/components/main-page/SearchField.tsx
@@ -1,27 +1,30 @@
 import { useState } from "react";
-import { ReadListing } from "~/BFF/WebBFF";
+import { GetFullListingDetail, ReadListing } from "~/BFF/WebBFF";
 import type { PropertyInterface } from "../types/PropertyInterface";
+import { useNavigate } from "react-router";
+import { IsValidURL } from "~/BFF/WebBFFHelper";
 
 export const SearchField = () => {
   const [listingURL, setListingURL] = useState("");
   const [loading, setLoading] = useState(false);
   const [property, setProperty] = useState<PropertyInterface | null>(null);
   const [error, setError] = useState("");
+  const navigate = useNavigate();
 
   //function to call the axios
-  const handleSearch = async () => {
-    try {
-      setLoading(true);
-      setError("");
-
-      const result = await ReadListing(parseInt(listingURL));
-      setProperty(result[0]);
-      console.log(result);
-    } catch {
-      setError("Failed to load property");
-    } finally {
-      setLoading(false);
+  const handleSearch = () => {
+    if (!listingURL.trim()) {
+      alert("Empty URL");
+      return;
     }
+    if(!IsValidURL(listingURL)) {
+      alert("Invalid URL.")
+      return;
+    }
+
+    navigate(`/before-after?url=${encodeURIComponent(listingURL)}`)      
+
+
   };
 
   return (

--- a/app/components/main-page/SearchField.tsx
+++ b/app/components/main-page/SearchField.tsx
@@ -16,14 +16,12 @@ export const SearchField = () => {
       alert("Empty URL");
       return;
     }
-    if(!IsValidURL(listingURL)) {
-      alert("Invalid URL.")
+    if (!IsValidURL(listingURL)) {
+      alert("Invalid URL.");
       return;
     }
 
-    navigate(`/before-after?url=${encodeURIComponent(listingURL)}`)      
-
-
+    navigate(`/before-after?url=${encodeURIComponent(listingURL)}`);
   };
 
   return (

--- a/app/components/main-page/SearchField.tsx
+++ b/app/components/main-page/SearchField.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { GetFullListingDetail, ReadListing } from "~/BFF/WebBFF";
 import type { PropertyInterface } from "../types/PropertyInterface";
 import { useNavigate } from "react-router";
 import { IsValidURL } from "~/BFF/WebBFFHelper";

--- a/app/components/prototype/AddressField.tsx
+++ b/app/components/prototype/AddressField.tsx
@@ -1,27 +1,50 @@
-import type { ListingResponseInterface } from "../types/ListingResponseInterface"
+import type { ListingResponseInterface } from "../types/ListingResponseInterface";
 import { Spinner } from "./Spinner";
 
-
 type AddressFieldProp = {
-    listing?: ListingResponseInterface;
-    loading: boolean;
-}
+  listing?: ListingResponseInterface;
+  loading: boolean;
+};
 
-export const AddressField = ({listing, loading}: AddressFieldProp) => {
-    if(loading) {
-        return (
-            <Spinner/>
-        )
-    }
-    if(!listing) {
-        return null;
-    }
-    return (
-        <div>
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            {listing.address}
-            </h2>
-            <p className="text-gray-700 mb-6">{listing.description}</p>
+export const AddressField = ({ listing, loading }: AddressFieldProp) => {
+  if (loading) {
+    return <Spinner />;
+  }
+  if (!listing) {
+    return null;
+  }
+  //formatting address
+  const addressParts = listing.address.split(" ");
+  const street = addressParts.slice(0, 3).join(" ");
+  const cityState = addressParts.slice(3, addressParts.length - 1).join(" ");
+  const zip = addressParts[addressParts.length - 1];
+  return (
+    <div>
+      <div className="text-3xl text-black font-medium mb-4">
+        ${listing.price.toLocaleString()}
+      </div>
+      <div className="text-2xl mb-6">
+        <div className="text-black font-medium">{street}</div>
+        <div className="text-gray-600 font-light">
+          {cityState}
+          {zip}
         </div>
-    )
-}
+      </div>
+      <div className="flex p-5 text-2xl border-gray-200 border-t-2 border-b-2 mb-6 justify-center items-center space-x-*">
+        <span className="flex justify-center w-full">
+          <span className="mr-2">{listing.bedroom}</span>
+          <span className="text-gray-600 font-light">Beds</span>
+        </span>
+        <div className="h-10 w-0.5 bg-gray-200 "></div>
+        <span className="flex justify-center w-full">
+          <span className="mr-2">{listing.bathroom}</span>
+          <span className="text-gray-600 font-light">Baths</span>
+        </span>
+      </div>
+      <h3 className="text-2xl font-medium text-black mb-2">About This Home</h3>
+      <p className="text-lg font-normal text-gray-600 mb-6">
+        {listing.description}
+      </p>
+    </div>
+  );
+};

--- a/app/components/prototype/AddressField.tsx
+++ b/app/components/prototype/AddressField.tsx
@@ -1,0 +1,27 @@
+import type { ListingResponseInterface } from "../types/ListingResponseInterface"
+import { Spinner } from "./Spinner";
+
+
+type AddressFieldProp = {
+    listing?: ListingResponseInterface;
+    loading: boolean;
+}
+
+export const AddressField = ({listing, loading}: AddressFieldProp) => {
+    if(loading) {
+        return (
+            <Spinner/>
+        )
+    }
+    if(!listing) {
+        return null;
+    }
+    return (
+        <div>
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            {listing.address}
+            </h2>
+            <p className="text-gray-700 mb-6">{listing.description}</p>
+        </div>
+    )
+}

--- a/app/components/prototype/BannerGallery.tsx
+++ b/app/components/prototype/BannerGallery.tsx
@@ -1,0 +1,64 @@
+import React, { useRef } from "react";
+import type { PhotoListing } from "~/components/types/PhotoListing";
+import { Spinner } from "./Spinner";
+
+type BannerGalleryProps = {
+  photos: PhotoListing[];
+  loading: boolean;
+};
+
+export const BannerGallery: React.FC<BannerGalleryProps> = ({
+  photos,
+  loading,
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const scrollLeft = () => {
+    scrollRef.current?.scrollBy({ left: -300, behavior: "smooth" });
+  };
+
+  const scrollRight = () => {
+    scrollRef.current?.scrollBy({ left: 300, behavior: "smooth" });
+  };
+
+  if (loading) {
+    return <Spinner />;
+  }
+  const hasPhotos = photos && Object.keys(photos).length > 0;
+  if (!hasPhotos) return null;
+
+  return (
+    <div className="relative">
+      <button
+        onClick={scrollLeft}
+        className="absolute left-0 top-1/2 -translate-y-1/2 z-10 bg-white rounded-full p-2 shadow-md"
+      >
+        &#8592;
+      </button>
+      <button
+        onClick={scrollRight}
+        className="absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-white rounded-full p-2 shadow-md"
+      >
+        &#8594;
+      </button>
+      <div
+        ref={scrollRef}
+        className="flex overflow-x-auto space-x-4 p-2 scrollbar-hide"
+      >
+        {photos.map((photo) => (
+          <div
+            key={photo.photo_id}
+            className="flex-shrink-0 w-100 h-100 snap-start"
+          >
+            <img
+              src={photo.url}
+              alt={`Photo ${photo.photo_id}`}
+              className="object-cover w-full h-full rounded-lg shadow-md"
+              loading="lazy"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/app/components/prototype/Gallery.tsx
+++ b/app/components/prototype/Gallery.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import type { PhotoListing } from "~/components/types/PhotoListing";
+import { Spinner } from "./Spinner";
+
+type RoomGallerySectionProps = {
+  groupedPhotos: Record<string, PhotoListing[]>;
+  loading: boolean;
+};
+
+export const Gallery: React.FC<RoomGallerySectionProps> = ({
+  groupedPhotos,
+  loading,
+}) => {
+  if (loading) {
+    return <Spinner />;
+  }
+  const hasPhotos = groupedPhotos && Object.keys(groupedPhotos).length > 0;
+  if (!hasPhotos) return null;
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-medium text-black mb-2">
+        Completed Renovations
+      </h2>
+      {Object.entries(groupedPhotos).map(([roomType, roomPhotos]) => (
+        <div key={roomType}>
+          <h2 className="text-2xl font-medium mb-4 text-gray-600">
+            {roomType}
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+            {roomPhotos.map((photo) => (
+              <div key={photo.photo_id}>
+                <img
+                  src={photo.url}
+                  alt={`${roomType} - ${photo.photo_id}`}
+                  className="object-cover w-full h-48 rounded-lg shadow-md"
+                  loading="lazy"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/app/components/prototype/Spinner.tsx
+++ b/app/components/prototype/Spinner.tsx
@@ -1,8 +1,7 @@
 export const Spinner = () => {
-    return (
-        <div className="flex justify-center items-center m-4">
-            <div className="h-8 w-8 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
-        </div>
-        
-    )
-}
+  return (
+    <div className="flex justify-center items-center m-4">
+      <div className="h-8 w-8 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
+    </div>
+  );
+};

--- a/app/components/prototype/Spinner.tsx
+++ b/app/components/prototype/Spinner.tsx
@@ -1,0 +1,8 @@
+export const Spinner = () => {
+    return (
+        <div className="flex justify-center items-center">
+            <div className="h-8 w-8 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin"></div>
+        </div>
+        
+    )
+}

--- a/app/components/prototype/Spinner.tsx
+++ b/app/components/prototype/Spinner.tsx
@@ -1,7 +1,7 @@
 export const Spinner = () => {
     return (
-        <div className="flex justify-center items-center">
-            <div className="h-8 w-8 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin"></div>
+        <div className="flex justify-center items-center m-4">
+            <div className="h-8 w-8 border-4 border-gray-300 border-t-gray-500 rounded-full animate-spin"></div>
         </div>
         
     )

--- a/app/components/types/FullListingDetailInterface.ts
+++ b/app/components/types/FullListingDetailInterface.ts
@@ -1,9 +1,9 @@
 import type { ListingInterface } from "./ListingInterface";
-import type { PhotoResponse } from "./PhotoResponse";
+import type { PhotoListing } from "./PhotoListing";
 import type { RenovationListingInterface } from "./RenovationListingInterface";
 
 export interface FullListingDetailInterface {
   listing: ListingInterface;
   renovation: RenovationListingInterface;
-  photos: PhotoResponse;
+  photos: PhotoListing[];
 }

--- a/app/components/types/ListingResponseInterface.ts
+++ b/app/components/types/ListingResponseInterface.ts
@@ -1,6 +1,5 @@
 export interface ListingResponseInterface {
   url: string;
-  image: string;
   address: string;
   description: string;
   price: number;

--- a/app/components/types/PhotoClassification.ts
+++ b/app/components/types/PhotoClassification.ts
@@ -1,0 +1,10 @@
+import type { PhotoListing } from "./PhotoListing";
+
+export interface PhotoClassification {
+  label: string;
+  confidence: number;
+}
+
+export interface ClassifiedPhotoListing extends PhotoListing {
+  classification: PhotoClassification;
+}

--- a/app/routes/listing.tsx
+++ b/app/routes/listing.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/home";
-import { BeforeAfterView } from "~/components/layouts/BeforeAfter";
+import { BeforeAfter } from "~/components/layouts/BeforeAfter";
 
 export function meta({}: Route.MetaArgs) {
   return [
@@ -9,5 +9,5 @@ export function meta({}: Route.MetaArgs) {
 }
 
 export default function Listing() {
-  return <BeforeAfterView />;
+  return <BeforeAfter />;
 }


### PR DESCRIPTION
Due to our original idea not being functional, we have decided to pivot to a Renovation Highlight page rather than a before-after page. 
This page will display the price, address, number of bedrooms and bathrooms, property descriptions, and renovation images. This is what it looks like right now:
<img width="1868" height="1632" alt="image" src="https://github.com/user-attachments/assets/33228bc5-d82b-41e6-ba5e-8d2580e714b0" />

The page will display the renovation data by checking which room have been renovated and then display all image that has been classified as that room underneath.
<img width="1630" height="1216" alt="image" src="https://github.com/user-attachments/assets/4206e0c6-a3e1-4cf2-a377-6269a0ea83dc" />

